### PR TITLE
feat: 構造化エラーハンドリングのためのAppErrパッケージを追加

### DIFF
--- a/pkg/apperr/apperr.go
+++ b/pkg/apperr/apperr.go
@@ -1,0 +1,209 @@
+package apperr
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"strings"
+
+	"google.golang.org/grpc/codes"
+)
+
+// AppErr represents an application error with gRPC status code compatibility.
+// It provides structured error handling with automatic stack trace capture,
+// gRPC status code mapping, and structured logging support.
+// AppErr implements the error interface and can be used with the standard
+// errors package functions like errors.Is and errors.As.
+type AppErr struct {
+	Cause error       // Original error that caused this AppErr (if any)
+	Code  codes.Code  // gRPC status code representing the error type
+	Msg   string      // Human-readable error message
+	Attrs []slog.Attr // Structured attributes for logging context
+}
+
+// Global error variables provide predefined AppErr instances for common gRPC status codes.
+// These can be used directly or as targets for errors.Is comparisons.
+var (
+	// ErrCanceled represents a canceled operation
+	ErrCanceled = &AppErr{Code: codes.Canceled}
+
+	// ErrUnknown represents an unknown error
+	ErrUnknown = &AppErr{Code: codes.Unknown}
+
+	// ErrInvalidArgument represents an invalid argument error
+	ErrInvalidArgument = &AppErr{Code: codes.InvalidArgument}
+
+	// ErrDeadlineExceeded represents a deadline exceeded error
+	ErrDeadlineExceeded = &AppErr{Code: codes.DeadlineExceeded}
+
+	// ErrNotFound represents a not found error
+	ErrNotFound = &AppErr{Code: codes.NotFound}
+
+	// ErrAlreadyExists represents an already exists error
+	ErrAlreadyExists = &AppErr{Code: codes.AlreadyExists}
+
+	// ErrPermissionDenied represents a permission denied error
+	ErrPermissionDenied = &AppErr{Code: codes.PermissionDenied}
+
+	// ErrResourceExhausted represents a resource exhausted error
+	ErrResourceExhausted = &AppErr{Code: codes.ResourceExhausted}
+
+	// ErrFailedPrecondition represents a failed precondition error
+	ErrFailedPrecondition = &AppErr{Code: codes.FailedPrecondition}
+
+	// ErrAborted represents an aborted operation error
+	ErrAborted = &AppErr{Code: codes.Aborted}
+
+	// ErrOutOfRange represents an out of range error
+	ErrOutOfRange = &AppErr{Code: codes.OutOfRange}
+
+	// ErrUnimplemented represents an unimplemented operation error
+	ErrUnimplemented = &AppErr{Code: codes.Unimplemented}
+
+	// ErrInternal represents an internal server error
+	ErrInternal = &AppErr{Code: codes.Internal}
+
+	// ErrUnavailable represents a service unavailable error
+	ErrUnavailable = &AppErr{Code: codes.Unavailable}
+
+	// ErrDataLoss represents a data loss error
+	ErrDataLoss = &AppErr{Code: codes.DataLoss}
+
+	// ErrUnauthenticated represents an unauthenticated request error
+	ErrUnauthenticated = &AppErr{Code: codes.Unauthenticated}
+)
+
+// Error implements the error interface.
+// Returns the formatted error message including the gRPC status code.
+func (e *AppErr) Error() string {
+	return e.Msg
+}
+
+// Unwrap returns the underlying cause error, if any.
+// This enables compatibility with the standard errors.Unwrap function.
+func (e *AppErr) Unwrap() error {
+	return e.Cause
+}
+
+// Is enables error checking with errors.Is.
+// Returns true if the target is an AppErr with the same Code, or if the Cause field matches the target.
+// This allows semantic error comparison based on error codes rather than exact instance matching.
+func (e *AppErr) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+	if t, ok := target.(*AppErr); ok {
+		// Compare by Code for semantic equivalence
+		return e.Code == t.Code
+	}
+	return errors.Is(e.Cause, target)
+}
+
+// LogValue implements slog.LogValuer, allowing AppErr to be logged as structured attributes.
+// When used with slog, this will output all error context as structured fields including
+// message, code, cause, and any additional attributes.
+func (e *AppErr) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.String("msg", e.Msg),
+		slog.String("code", e.Code.String()),
+	}
+	if e.Cause != nil {
+		attrs = append(attrs, slog.String("cause", e.Cause.Error()))
+	}
+
+	anyAttrs := make([]any, len(e.Attrs))
+	for i, attr := range e.Attrs {
+		anyAttrs[i] = attr
+	}
+
+	attrs = append(attrs, slog.Group("attrs", anyAttrs...))
+
+	return slog.GroupValue(attrs...)
+}
+
+// New creates a new AppErr instance without a cause error.
+// The message is automatically formatted to include the gRPC status code.
+// A stack trace is automatically captured and included in the attributes.
+// Use this when there is no underlying error to wrap.
+func New(code codes.Code, msg string, attrs ...slog.Attr) error {
+	attrs = append(attrs, withStack())
+	return &AppErr{
+		Code:  code,
+		Msg:   fmt.Sprintf("%s (%s)", msg, code),
+		Attrs: attrs,
+	}
+}
+
+// Wrap wraps an existing error with additional context and gRPC status code.
+// If the error is already an AppErr, it will be flattened and the messages will be concatenated.
+//
+// Note: When wrapping an existing AppErr, its original Code field will be overridden by the given code.
+// A stack trace is automatically captured and included in the attributes.
+// Use this to wrap existing errors with additional context and gRPC status code.
+func Wrap(err error, code codes.Code, msg string, attrs ...slog.Attr) error {
+	attrs = append(attrs, withStack())
+
+	// If err is already an AppErr, flatten the chain
+	var appErr *AppErr
+	if !errors.As(err, &appErr) {
+		// Original behavior for non-AppErr errors
+		return &AppErr{
+			Cause: err,
+			Code:  code,
+			Msg:   fmt.Sprintf("%s: %s (%s)", msg, err.Error(), code),
+			Attrs: attrs,
+		}
+	}
+
+	// Concatenate messages: new message + old AppErr's message
+	combinedMsg := fmt.Sprintf("%s (%s): %s", msg, code, appErr.Msg)
+
+	// Merge attributes, keeping original stack trace and filtering duplicates from new attrs
+	var mergedAttrs []slog.Attr
+	mergedAttrs = append(mergedAttrs, appErr.Attrs...)
+
+	// Add new attributes, but skip stack traces to avoid duplication
+	for _, attr := range attrs {
+		if attr.Key != "stacktrace" {
+			mergedAttrs = append(mergedAttrs, attr)
+		}
+	}
+
+	cause := appErr.Cause
+	if cause == nil {
+		cause = appErr
+	}
+
+	return &AppErr{
+		Cause: cause,       // Keep the original cause
+		Code:  code,        // Use new code
+		Msg:   combinedMsg, // Concatenated message
+		Attrs: mergedAttrs, // Merge attributes (keeping original stack trace)
+	}
+}
+
+// withStack captures the current stack trace and returns it as a slog attribute.
+// This is used internally by New and Wrap to automatically include stack traces.
+func withStack() slog.Attr {
+	var pcs [32]uintptr
+	n := runtime.Callers(3, pcs[:]) // Skip withStack and New/Wrap
+	if n == 0 {
+		return slog.String("stacktrace", "unknown")
+	}
+
+	var sb strings.Builder
+	var lines []string
+	lines = append(lines, "goroutine 1 [running]:") // Mock goroutine header
+
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		sb.WriteString(fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line))
+		if !more {
+			break
+		}
+	}
+
+	return slog.String("stacktrace", sb.String())
+}

--- a/pkg/apperr/apperr_test.go
+++ b/pkg/apperr/apperr_test.go
@@ -1,0 +1,635 @@
+package apperr
+
+import (
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+)
+
+// Interface method tests - verify AppErr implements error interface correctly
+
+func TestAppErr_Error(t *testing.T) {
+	tests := []struct {
+		name   string
+		appErr *AppErr
+		want   string
+	}{
+		{
+			name: "returns formatted message when no cause error",
+			appErr: &AppErr{
+				Code: codes.InvalidArgument,
+				Msg:  "invalid input (InvalidArgument)",
+			},
+			want: "invalid input (InvalidArgument)",
+		},
+		{
+			name: "returns formatted message when cause error exists",
+			appErr: &AppErr{
+				Cause: errors.New("database error"),
+				Code:  codes.Internal,
+				Msg:   "failed to process request: database error (Internal)",
+			},
+			want: "failed to process request: database error (Internal)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.appErr.Error(); got != tt.want {
+				t.Errorf("AppErr.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppErr_Unwrap(t *testing.T) {
+	originalErr := errors.New("original error")
+
+	tests := []struct {
+		name   string
+		appErr *AppErr
+		want   error
+	}{
+		{
+			name: "returns underlying cause when present",
+			appErr: &AppErr{
+				Cause: originalErr,
+				Code:  codes.Internal,
+				Msg:   "test error: original error (Internal)",
+			},
+			want: originalErr,
+		},
+		{
+			name: "returns nil when no underlying cause",
+			appErr: &AppErr{
+				Code: codes.InvalidArgument,
+				Msg:  "test error (InvalidArgument)",
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.want == nil {
+				if got := tt.appErr.Unwrap(); got != nil {
+					t.Errorf("AppErr.Unwrap() = %v, want nil", got)
+				}
+			} else {
+				if got := tt.appErr.Unwrap(); !errors.Is(got, tt.want) {
+					t.Errorf("AppErr.Unwrap() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestAppErr_Is(t *testing.T) {
+	originalErr := errors.New("original error")
+
+	type args struct {
+		target error
+	}
+	tests := []struct {
+		name   string
+		appErr *AppErr
+		args   args
+		want   bool
+	}{
+		{
+			name: "returns true when underlying cause matches target",
+			appErr: &AppErr{
+				Cause: sql.ErrNoRows,
+				Code:  codes.Internal,
+				Msg:   "test error",
+			},
+			args: args{
+				target: sql.ErrNoRows,
+			},
+			want: true,
+		},
+		{
+			name: "returns false when underlying cause does not match target",
+			appErr: &AppErr{
+				Cause: sql.ErrNoRows,
+				Code:  codes.Internal,
+				Msg:   "test error",
+			},
+			args: args{
+				target: sql.ErrTxDone,
+			},
+			want: false,
+		},
+		{
+			name: "returns false when no underlying cause",
+			appErr: &AppErr{
+				Code: codes.InvalidArgument,
+				Msg:  "test error",
+			},
+			args: args{
+				target: originalErr,
+			},
+			want: false,
+		},
+		{
+			name: "returns true when target is AppErr with same gRPC code",
+			appErr: &AppErr{
+				Cause: sql.ErrNoRows,
+				Code:  codes.Internal,
+				Msg:   "test error",
+			},
+			args: args{
+				target: ErrInternal,
+			},
+			want: true,
+		},
+		{
+			name: "returns false when target is AppErr with different gRPC code",
+			appErr: &AppErr{
+				Cause: sql.ErrNoRows,
+				Code:  codes.Internal,
+				Msg:   "test error",
+			},
+			args: args{
+				target: ErrInvalidArgument,
+			},
+			want: false,
+		},
+		{
+			name: "returns true when both AppErrs have same code and no cause",
+			appErr: &AppErr{
+				Code: codes.NotFound,
+				Msg:  "test error",
+			},
+			args: args{
+				target: ErrNotFound,
+			},
+			want: true,
+		},
+		{
+			name: "returns false when both AppErrs have different codes and no cause",
+			appErr: &AppErr{
+				Code: codes.NotFound,
+				Msg:  "test error",
+			},
+			args: args{
+				target: ErrInternal,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.appErr.Is(tt.args.target); got != tt.want {
+				t.Errorf("AppErr.Is() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppErr_LogValue(t *testing.T) {
+	originalErr := errors.New("database error")
+	attrs := []slog.Attr{
+		slog.String("user_id", "123"),
+		slog.Int("attempt", 3),
+	}
+
+	tests := []struct {
+		name      string
+		appErr    *AppErr
+		want      map[string]string // expected top-level key-value pairs
+		wantAttrs map[string]string // expected attributes in the attrs group
+	}{
+		{
+			name: "includes all fields when underlying cause is present",
+			appErr: &AppErr{
+				Cause: originalErr,
+				Code:  codes.Internal,
+				Msg:   "test error",
+				Attrs: attrs,
+			},
+			want: map[string]string{
+				"msg":   "test error",
+				"code":  "Internal",
+				"cause": "database error",
+			},
+			wantAttrs: map[string]string{
+				"user_id": "123",
+				"attempt": "3",
+			},
+		},
+		{
+			name: "includes fields when no underlying cause",
+			appErr: &AppErr{
+				Code:  codes.InvalidArgument,
+				Msg:   "test error",
+				Attrs: attrs,
+			},
+			want: map[string]string{
+				"msg":  "test error",
+				"code": "InvalidArgument",
+			},
+			wantAttrs: map[string]string{
+				"user_id": "123",
+				"attempt": "3",
+			},
+		},
+		{
+			name: "handles empty attributes",
+			appErr: &AppErr{
+				Code:  codes.NotFound,
+				Msg:   "not found",
+				Attrs: nil,
+			},
+			want: map[string]string{
+				"msg":  "not found",
+				"code": "NotFound",
+			},
+			wantAttrs: map[string]string{},
+		},
+		{
+			name: "handles AppErr as cause",
+			appErr: &AppErr{
+				Cause: &AppErr{
+					Code: codes.InvalidArgument,
+					Msg:  "invalid input",
+				},
+				Code:  codes.Internal,
+				Msg:   "wrapped error",
+				Attrs: attrs,
+			},
+			want: map[string]string{
+				"msg":   "wrapped error",
+				"code":  "Internal",
+				"cause": "invalid input (InvalidArgument)",
+			},
+			wantAttrs: map[string]string{
+				"user_id": "123",
+				"attempt": "3",
+			},
+		},
+		{
+			name: "handles nil cause",
+			appErr: &AppErr{
+				Cause: nil,
+				Code:  codes.Unknown,
+				Msg:   "unknown error",
+				Attrs: attrs,
+			},
+			want: map[string]string{
+				"msg":  "unknown error",
+				"code": "Unknown",
+			},
+			wantAttrs: map[string]string{
+				"user_id": "123",
+				"attempt": "3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logValue := tt.appErr.LogValue()
+			if logValue.Kind() != slog.KindGroup {
+				t.Errorf("LogValue() should return a group, got %v", logValue.Kind())
+			}
+
+			group := logValue.Group()
+			if group == nil {
+				t.Fatal("LogValue() group should not be nil")
+			}
+
+			fieldLen := len(tt.want)
+			if len(tt.wantAttrs) > 0 {
+				fieldLen++
+			}
+
+			if len(group) != fieldLen {
+				t.Errorf("Expected %d attributes, got %d", fieldLen, len(group))
+			}
+
+			for _, attr := range group {
+				if attr.Key == "attrs" {
+					validateAttrsGroup(t, attr.Value.Group(), tt.wantAttrs)
+				} else {
+					if _, exists := tt.want[attr.Key]; !exists {
+						t.Errorf("Unexpected attribute found: %s=%s", attr.Key, attr.Value.String())
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func validateAttrsGroup(t *testing.T, attrsGroup []slog.Attr, wantAttrs map[string]string) {
+	for _, attr := range attrsGroup {
+		if _, exists := wantAttrs[attr.Key]; !exists {
+			t.Errorf("Unexpected attribute found in attrs group: %s=%s", attr.Key, attr.Value.String())
+		}
+	}
+}
+
+// Constructor tests - verify New and Wrap functions work correctly
+
+func TestNew(t *testing.T) {
+	type args struct {
+		code  codes.Code
+		msg   string
+		attrs []slog.Attr
+	}
+	type want struct {
+		err      error
+		code     codes.Code
+		attrs    []slog.Attr
+		errorStr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "creates AppErr with attributes and stack trace",
+			args: args{
+				code:  codes.InvalidArgument,
+				msg:   "invalid email format",
+				attrs: []slog.Attr{slog.String("field", "email"), slog.String("value", "invalid-email")},
+			},
+			want: want{
+				err:      ErrInvalidArgument,
+				code:     codes.InvalidArgument,
+				attrs:    []slog.Attr{slog.String("field", "email"), slog.String("value", "invalid-email")},
+				errorStr: "invalid email format (InvalidArgument)",
+			},
+		},
+		{
+			name: "creates AppErr without additional attributes",
+			args: args{
+				code:  codes.Internal,
+				msg:   "internal server error",
+				attrs: nil,
+			},
+			want: want{
+				err:      ErrInternal,
+				code:     codes.Internal,
+				attrs:    nil,
+				errorStr: "internal server error (Internal)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := New(tt.args.code, tt.args.msg, tt.args.attrs...)
+
+			// Assert that errors.Is(err, want.err) is true
+			if !errors.Is(err, tt.want.err) {
+				t.Errorf("errors.Is(err, want.err) = false, want true (err: %v, want.err: %v)", err, tt.want.err)
+			}
+
+			// Extract AppErr for testing
+			var appErr *AppErr
+			if !errors.As(err, &appErr) {
+				t.Fatal("New() should return an error that can be converted to *AppErr")
+			}
+
+			// Test basic fields
+			if appErr.Cause != nil {
+				t.Errorf("New() Cause should be nil, got %v", appErr.Cause)
+			}
+			if appErr.Code != tt.want.code {
+				t.Errorf("New() Code = %v, want %v", appErr.Code, tt.want.code)
+			}
+
+			// Test attributes
+			expectedCount := len(tt.want.attrs) + 1 // +1 for stacktrace
+			if len(appErr.Attrs) != expectedCount {
+				t.Errorf("Expected %d attributes, got %d", expectedCount, len(appErr.Attrs))
+			}
+
+			// Validate each attribute
+			for _, attr := range appErr.Attrs {
+				if attr.Key == "stacktrace" {
+					validateStackTrace(t, attr.Value.String())
+					continue
+				}
+				if !containsAttr(tt.want.attrs, attr) {
+					t.Errorf("Unexpected attribute found: %s = %s", attr.Key, attr.Value.String())
+				}
+			}
+
+			// Test error string
+			if err.Error() != tt.want.errorStr {
+				t.Errorf("New() Error() = %v, want %v", err.Error(), tt.want.errorStr)
+			}
+		})
+	}
+}
+
+func TestWrap(t *testing.T) {
+	type args struct {
+		err   error
+		code  codes.Code
+		msg   string
+		attrs []slog.Attr
+	}
+	type want struct {
+		err      error
+		cause    error
+		code     codes.Code
+		attrs    []slog.Attr
+		errorStr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "wraps standard error with attributes and stack trace",
+			args: args{
+				err:   sql.ErrNoRows,
+				code:  codes.NotFound,
+				msg:   "failed to create user",
+				attrs: []slog.Attr{slog.String("user_id", "123"), slog.String("operation", "create_user")},
+			},
+			want: want{
+				err:      ErrNotFound,
+				cause:    sql.ErrNoRows,
+				code:     codes.NotFound,
+				attrs:    []slog.Attr{slog.String("user_id", "123"), slog.String("operation", "create_user")},
+				errorStr: "failed to create user: sql: no rows in result set (NotFound)",
+			},
+		},
+		{
+			name: "wraps standard error without additional attributes",
+			args: args{
+				err:   sql.ErrTxDone,
+				code:  codes.FailedPrecondition,
+				msg:   "invalid input",
+				attrs: nil,
+			},
+			want: want{
+				err:      ErrFailedPrecondition,
+				cause:    sql.ErrTxDone,
+				code:     codes.FailedPrecondition,
+				attrs:    nil,
+				errorStr: "invalid input: sql: transaction has already been committed or rolled back (FailedPrecondition)",
+			},
+		},
+		{
+			name: "flattens AppErr created by New and concatenates messages",
+			args: args{
+				err:   New(codes.InvalidArgument, "invalid email format", slog.String("field", "email")),
+				code:  codes.Internal,
+				msg:   "failed to create user",
+				attrs: []slog.Attr{slog.String("user_id", "123"), slog.String("operation", "create_user")},
+			},
+			want: want{
+				err:      ErrInternal,
+				cause:    New(codes.InvalidArgument, "invalid email format", slog.String("field", "email")), // AppErr is used if cause is nil
+				code:     codes.Internal,
+				attrs:    []slog.Attr{slog.String("field", "email"), slog.String("user_id", "123"), slog.String("operation", "create_user")},
+				errorStr: "failed to create user (Internal): invalid email format (InvalidArgument)",
+			},
+		},
+		{
+			name: "flattens AppErr created by New without additional attributes",
+			args: args{
+				err:   New(codes.NotFound, "user not found"),
+				code:  codes.Internal,
+				msg:   "database operation failed",
+				attrs: nil,
+			},
+			want: want{
+				err:      ErrInternal,
+				cause:    New(codes.NotFound, "user not found"), // AppErr is used if cause is nil
+				code:     codes.Internal,
+				attrs:    nil,
+				errorStr: "database operation failed (Internal): user not found (NotFound)",
+			},
+		},
+		{
+			name: "flattens AppErr created by Wrap and preserves original cause",
+			args: args{
+				err:   Wrap(sql.ErrNoRows, codes.NotFound, "invalid input"),
+				code:  codes.Internal,
+				msg:   "failed to process request",
+				attrs: []slog.Attr{slog.String("request_id", "abc123")},
+			},
+			want: want{
+				err:      ErrInternal,
+				cause:    sql.ErrNoRows, // Original underlying error
+				code:     codes.Internal,
+				attrs:    []slog.Attr{slog.String("request_id", "abc123")},
+				errorStr: "failed to process request (Internal): invalid input: sql: no rows in result set (NotFound)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Wrap(tt.args.err, tt.args.code, tt.args.msg, tt.args.attrs...)
+
+			// Assert that errors.Is(err, want.err) is true
+			if !errors.Is(err, tt.want.err) {
+				t.Errorf("errors.Is(err, want.err) = false, want true (err: %v, want.err: %v)", err, tt.want.err)
+			}
+
+			// Extract AppErr for testing
+			var appErr *AppErr
+			if !errors.As(err, &appErr) {
+				t.Fatal("Wrap() should return an error that can be converted to *AppErr")
+			}
+
+			// Test basic fields
+			if tt.want.cause == nil {
+				if appErr.Cause != nil {
+					t.Errorf("Wrap() Cause should be nil, got %v", appErr.Cause)
+				}
+			} else {
+				if !errors.Is(appErr.Cause, tt.want.cause) {
+					t.Errorf("Wrap() Cause = %v, want %v", appErr.Cause, tt.want.cause)
+				}
+			}
+			if appErr.Code != tt.want.code {
+				t.Errorf("Wrap() Code = %v, want %v", appErr.Code, tt.want.code)
+			}
+
+			// Test attributes
+			expectedCount := len(tt.want.attrs) + 1 // +1 for stacktrace
+			if len(appErr.Attrs) != expectedCount {
+				t.Errorf("Expected %d attributes, got %d", expectedCount, len(appErr.Attrs))
+			}
+
+			// Validate each attribute
+			for _, attr := range appErr.Attrs {
+				if attr.Key == "stacktrace" {
+					validateStackTrace(t, attr.Value.String())
+					continue
+				}
+				if !containsAttr(tt.want.attrs, attr) {
+					t.Errorf("Unexpected attribute found: %s = %s", attr.Key, attr.Value.String())
+				}
+			}
+
+			// Test error string
+			if err.Error() != tt.want.errorStr {
+				t.Errorf("Wrap() Error() = %v, want %v", err.Error(), tt.want.errorStr)
+			}
+
+			// Test As method
+			var target *AppErr
+			if !errors.As(err, &target) {
+				t.Error("Wrap() should return true for errors.As(&AppErr)")
+			}
+		})
+	}
+}
+
+// Helper functions for testing
+
+// validateStackTrace validates that the stack trace is properly formatted
+// and contains expected package information, and that the caller is present in the first stack frame
+func validateStackTrace(t *testing.T, stackTrace string) {
+	if stackTrace == "" {
+		t.Error("Stack trace should not be empty")
+	}
+
+	lines := strings.Split(stackTrace, "\n")
+
+	if len(lines) < 2 {
+		t.Errorf("Stack trace should have at least 2 lines, got %d", len(lines))
+	}
+
+	// Check that the the first stack frame is the caller of either New or Wrap
+	if !strings.Contains(lines[0], "TestWrap") && !strings.Contains(lines[0], "TestNew") {
+		t.Errorf("Stack trace should contain a caller (TestWrap or TestNew) at the first stack frame, got: %s", lines[0])
+	}
+
+}
+
+// min returns the minimum of two integers
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// containsAttr checks if an attribute exists in the want list
+// by comparing both key and value
+func containsAttr(want []slog.Attr, attr slog.Attr) bool {
+	for _, e := range want {
+		if e.Key == attr.Key && e.Value.String() == attr.Value.String() {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 概要

gRPC ステータスコード対応の構造化エラーハンドリングパッケージ `AppErr` を追加しました。

## 主な機能

### AppErr 構造体

- gRPC ステータスコードとの互換性
- 自動スタックトレース取得
- 構造化ログ対応（slog.LogValuer 実装）
- 標準 errors パッケージとの互換性（errors.Is, errors.As）

### コンストラクタ

- `New()`: 原因エラーなしで AppErr を作成
- `Wrap()`: 既存エラーをラップしてコンテキストを追加
- 両方とも自動的にスタックトレースを取得

### グローバルエラー変数

- 一般的な gRPC ステータスコード用の事前定義済み AppErr インスタンス
- `ErrNotFound`, `ErrInternal`, `ErrInvalidArgument` など

### エラーフラット化機能

- `Wrap()`で AppErr をラップする際、エラーチェーンをフラット化
- メッセージの連結と属性のマージ

## 技術的な詳細

### スタックトレース

- `runtime.Callers()`を使用した効率的なスタックトレース取得
- 標準 Go スタックトレース形式での出力

### セマンティックエラー比較

- gRPC コードベースのエラー比較（`errors.Is(err, apperr.ErrNotFound)`）
- 正確なインスタンスマッチングではなく、意味的な等価性を提供

### 構造化ログ

- slog.LogValuer インターフェースの実装
- エラーコンテキストを構造化フィールドとして出力

## テスト

- 包括的なテーブル駆動テスト
- エラーインターフェースメソッドの検証
- スタックトレース検証
- 構造化ログ出力の検証

## 使用例

```go
// 基本的な使用
err := apperr.New(codes.InvalidArgument, "無効な入力")

// エラーのラップ
err = apperr.Wrap(dbErr, codes.Internal, "データベース操作に失敗")

// エラー比較
if errors.Is(err, apperr.ErrNotFound) {
    // 処理
}

// 構造化ログ
logger.Error("エラーが発生", "error", err)
```

## 関連 Issue

- SOA-394
